### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ homepage = "https://github.com/smol-rs/async-rustls"
 documentation = "https://docs.rs/async-rustls"
 keywords = ["rustls", "tls", "ssl", "synchronization"]
 categories = ["asynchronous", "cryptography", "network-programming"]
-readme = "README.md"
 
 [features]
 default = ["logging"]


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.