### PR TITLE
implement a trait to abstract over async tls acceptors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ quic = ["rustls/quic"]
 [dependencies]
 futures-lite = "1.10.1"
 webpki = "0.21"
+async-tls-acceptor = "0.1.0"
 
 [dependencies.rustls]
 version = "0.19"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,18 @@ impl TlsAcceptor {
     }
 }
 
+#[async_tls_acceptor::async_trait]
+impl<Input> async_tls_acceptor::Acceptor<Input> for TlsAcceptor
+where
+    Input: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+{
+    type Output = server::TlsStream<Input>;
+    type Error = std::io::Error;
+    async fn accept(&self, input: Input) -> Result<Self::Output, Self::Error> {
+        TlsAcceptor::accept(&self, input).await
+    }
+}
+
 /// Future returned from `TlsConnector::connect` which will resolve
 /// once the connection handshake has finished.
 pub struct Connect<IO>(MidHandshake<client::TlsStream<IO>>);


### PR DESCRIPTION
This provides an implementation for a simple crate with a single trait, allowing server authors to accept either this crate or async-native-tls. See https://github.com/async-email/async-native-tls/pull/30 for the equivalent PR over there. As mentioned over there, if this goes well, I'll take a look at a trait for client-side connectors.

Thanks!