### PR TITLE
Update Rustls dependency to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 
 [dependencies]
 futures-io = "0.3.24"
-rustls = { version = "0.20", default-features = false }
+rustls = { version = "0.21", default-features = false }
 webpki = "0.22"
 
 [features]


### PR DESCRIPTION
Rustls 0.21 introduced long-waited features like support for TLS certificates containing IP addresses and support for RFC8446 C.4 client tracking prevention.

This PR bumps the Rustls version to 0.21 from 0.20.