### PR TITLE
v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.4.0
+
+- **Breaking:** Update rustls to 0.21. (#14)
+- **Breaking::** Remove webpki from the public API. (#15, #17)
+
 # Version 0.3.0
 
 - Update rustls to 0.20. (#9)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-rustls"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
   "Alex Crichton <alex@alexcrichton.com>",
   "quininer kel <quininer@live.com>",


### PR DESCRIPTION
- **Breaking:** Update rustls to 0.21. (#14)
- **Breaking::** Remove webpki from the public API. (#15, #17)