### PR TITLE
Migrate to Rust 2021

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,13 @@ jobs:
         run: cargo check -Z features=dev_dep
       - run: cargo test
 
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack build --workspace --no-private --no-dev-deps --rust-version
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/async-rustls"
 readme = "README.md"
 description = "Asynchronous TLS/SSL streams using Rustls."
 categories = ["asynchronous", "cryptography", "network-programming"]
-edition = "2018"
+edition = "2021"
 
 [workspace]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 description = "Asynchronous TLS/SSL streams using Rustls."
 categories = ["asynchronous", "cryptography", "network-programming"]
 edition = "2021"
+rust-version = "1.60"
 
 [workspace]
 resolver = "2"

--- a/examples/client/Cargo.toml
+++ b/examples/client/Cargo.toml
@@ -2,7 +2,8 @@
 name = "client"
 version = "0.1.0"
 authors = ["quininer <quininer@live.com>", "John Nunley <jtnunley01@gmail.com>"]
-edition = "2018"
+edition = "2021"
+publish = false
 
 [dependencies]
 argh = "0.1"

--- a/examples/client/src/main.rs
+++ b/examples/client/src/main.rs
@@ -5,7 +5,6 @@ use smol::io::{copy, split, AsyncWriteExt};
 use smol::net::TcpStream;
 use smol::prelude::*;
 use smol::Unblock;
-use std::convert::TryFrom;
 use std::fs::File;
 use std::io;
 use std::io::BufReader;

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -2,7 +2,8 @@
 name = "server"
 version = "0.1.0"
 authors = ["quininer <quininer@live.com>", "John Nunley <jtnunley01@gmail.com>"]
-edition = "2018"
+edition = "2021"
+publish = false
 
 [dependencies]
 argh = "0.1"

--- a/src/common/test_stream.rs
+++ b/src/common/test_stream.rs
@@ -256,8 +256,6 @@ fn stream_eof() -> io::Result<()> {
 }
 
 fn make_pair() -> (ServerConnection, ClientConnection) {
-    use std::convert::TryFrom;
-
     let (sconfig, cconfig) = utils::make_configs();
     let server = ServerConnection::new(sconfig).unwrap();
 

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -5,7 +5,6 @@ use async_rustls::{
 };
 use smol::io::{AsyncReadExt, AsyncWriteExt};
 use smol::net::TcpStream;
-use std::convert::TryFrom;
 use std::io;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;

--- a/tests/early-data.rs
+++ b/tests/early-data.rs
@@ -9,7 +9,6 @@ use smol::net::TcpStream;
 use smol::prelude::*;
 use smol::Timer;
 use smol::{future, future::Future};
-use std::convert::TryFrom;
 use std::io::{self, BufRead, BufReader, Cursor};
 use std::net::SocketAddr;
 use std::pin::Pin;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,7 +6,6 @@ use rustls_pemfile::{certs, rsa_private_keys};
 use smol::io::{copy, split, AssertAsync, AsyncReadExt, AsyncWriteExt};
 use smol::net::{TcpListener, TcpStream};
 use smol::prelude::*;
-use std::convert::TryFrom;
 use std::io::{BufReader, Cursor, ErrorKind};
 use std::net::SocketAddr;
 use std::sync::mpsc::channel;


### PR DESCRIPTION
rustls's MSRV (1.60) is higher than 1.56 that Rust 2021 was stabilized.

This also adds MSRV check to CI.