### PR TITLE
Bump MSRV to 1.61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 description = "Asynchronous TLS/SSL streams using Rustls."
 categories = ["asynchronous", "cryptography", "network-programming"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.61"
 
 [workspace]
 resolver = "2"


### PR DESCRIPTION
rustls requires it.

```
error: package `rustls v0.21.8` cannot be built because it requires rustc 1.61 or newer, while the currently active rustc version is 1.60.0
```