### PR TITLE
Deprecate in favor of futures-rustls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  RUSTFLAGS: -D warnings
+  RUSTFLAGS: -D warnings -A deprecated
   RUSTDOCFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.4.2
+
+- This crate is now deprecated in favor of [futures-rustls](https://crates.io/crates/futures-rustls).
+
 # Version 0.4.1
 
 - Add `smol-rs` logo to docs. (#23)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-rustls"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
   "Alex Crichton <alex@alexcrichton.com>",
   "quininer kel <quininer@live.com>",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# async-rustls
+# async-rustls (deprecated)
 
 [![Build](https://github.com/smol-rs/async-rustls/workflows/Build%20and%20test/badge.svg)](
 https://github.com/smol-rs/async-rustls/actions)
@@ -8,6 +8,8 @@ https://github.com/smol-rs/async-rustls)
 https://crates.io/crates/async-rustls)
 [![Documentation](https://docs.rs/async-rustls/badge.svg)](
 https://docs.rs/async-rustls)
+
+**This crate is now deprecated in favor of [futures-rustls](https://crates.io/crates/futures-rustls).**
 
 Asynchronous TLS/SSL streams using [`rustls`].
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,10 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
+#![deprecated(
+    since = "0.4.2",
+    note = "This crate is now deprecated in favor of [futures-rustls](https://crates.io/crates/futures-rustls)."
+)]
 
 macro_rules! ready {
     ( $e:expr ) => {


### PR DESCRIPTION
As discussed in #33, deprecate this crate in favor of https://github.com/rustls/futures-rustls.

Closes #33